### PR TITLE
Contributors label changes

### DIFF
--- a/content/assets/css/hl7au.css
+++ b/content/assets/css/hl7au.css
@@ -1,33 +1,45 @@
-/* Generic settings common to all HL7 IGs */
+/* Generic settings common to all HL7 AU IGs */
 :root {
 	--stu-note-background-color: #fff2ff; /* 19. (STU) Note box background color */
 	--stu-note-border-left-color: #ffa0ff; /* 20. (STU) Note box border color */
+	--contributors-note-background-color: #f2f2ff; /* 21. (Contributors) Note box border color */
+	--contributors-note-border-left-color: #a0a0ff; /* 21. (Contributors) Note box border color */
   }
   
 
-  /* Request For feedback, Note To Contributors styling */
-
-  .request-for-feedback,.note-to-contributors {
-	  margin: 5px;
-	  padding: 10px;
-	  border-left-style: solid;
-	  background-color: var(--stu-note-background-color);
-	  border-left-color: var(--stu-note-border-left-color);
-  }
-  
-  .request-for-feedback::before {
+   .request-for-feedback::before {
 	  white-space: pre;
 	  content: "Request For Feedback\A";
 	  background: yellow;
 	  color: red;
 	  font-weight: bold;
 	}
-  
+
+   .request-for-feedback {
+	  margin: 5px;
+	  padding: 10px;
+	  border-left-style: solid;
+	  background-color: var(--stu-note-background-color);
+	  border-left-color: var(--stu-note-border-left-color);
+  }
+
   .note-to-contributors::before {
 	  white-space: pre;
-	  content: "Note To Contributors\A";
+	  content: "Contributors\A";
 	  background: yellow;
 	  color: red;
 	  font-weight: bold;
 	}
+ 
+ .note-to-contributors {
+	  margin: 5px;
+	  padding: 10px;
+	  border-left-style: solid;
+	  background-color: var(--contributors-note-background-color);
+	  border-left-color: var(--contributors-note-border-left-color);
+  }
+
+
+
+
   

--- a/package-list.json
+++ b/package-list.json
@@ -12,14 +12,22 @@
       "current" : true
     },
     {
+      "version" : "0.7.1",
+      "path" : "http://fhir.org/templates/hl7.au.fhir.template/0.7.1",
+      "status" : "release",
+      "sequence" : "Publications",
+      "fhirversion" : "4.0.1",
+      "desc" : "Revised CSS styling",
+      "current" : true
+    },
+    {
       "version" : "0.7.0",
       "path" : "http://fhir.org/templates/hl7.au.fhir.template/0.7.0",
       "status" : "release",
       "sequence" : "Publications",
       "fhirversion" : "4.0.1",
       "desc" : "Upgrade to add CSS for new labels",
-      "date" : "2024-01-18",
-      "current" : true
+      "date" : "2024-01-18"
     },
     {
       "version" : "0.6.0",


### PR DESCRIPTION
Contributors label changes: 

- Renamed from 'Notes to Contributors' to 'Contributors'
- Changed background & left border colour
- Created an entry in the package-list for this version but without the date (Grahame adds date when he publishes the template)