### PR TITLE
Upgrade for dependency on fhir.base.template v0.9.0.

### DIFF
--- a/package-list.json
+++ b/package-list.json
@@ -12,13 +12,21 @@
       "current" : true
     },
     {
+      "version" : "0.10.0",
+      "path" : "http://fhir.org/templates/hl7.au.fhir.template/0.10.0",
+      "status" : "release",
+      "sequence" : "Publications",
+      "fhirversion" : "4.0.1",
+      "desc" : "Upgrade for dependency on fhir.base.template v0.9.0.",
+      "current" : true
+    },
+    {
       "version" : "0.9.0",
       "path" : "http://fhir.org/templates/hl7.au.fhir.template/0.9.0",
       "status" : "release",
       "sequence" : "Publications",
       "fhirversion" : "4.0.1",
       "desc" : "Update footer to match international version, redirecting 'propose a change' to Jira.",
-      "current" : true,
       "date" : "2024-04-25"
     },
     {

--- a/package/package.json
+++ b/package/package.json
@@ -7,7 +7,7 @@
   "canonical" : "http://fhir.org/templates/hl7.au.fhir.template",
   "base" : "hl7.au.base.template",
   "dependencies" : {
-    "hl7.au.base.template" : "current"
+    "hl7.au.base.template" : "0.9.0"
   },
-  "version" : "0.9.0"
+  "version" : "0.10.0"
 }


### PR DESCRIPTION
v0.10.0 - Upgraded for dependency on fhir.base.template v0.9.0.