### PR TITLE
v0.11.0: Update header image URL to point to HL7 AU website & update dependency on au base template 0.10.0

### DIFF
--- a/includes/_append.fragment-header.html
+++ b/includes/_append.fragment-header.html
@@ -1,5 +1,6 @@
         <div id="family-nav">
-          <a id="family-logo" no-external="true" href="http://hl7.org.au/fhir"><img height="50" alt="Visit the FHIR website" src="{{site.data.info.assets}}assets/images/fhir-au-logo-www.png"/> </a>
+          <a id="family-logo" no-external="true" href="http://hl7.com.au">
+            <img height="50" alt="Visit the HL7 Australia website" src="{{site.data.info.assets}}assets/images/fhir-au-logo-www.png"/> </a>
         </div>
 
         <!--<div id="hl7-search">

--- a/package-list.json
+++ b/package-list.json
@@ -12,13 +12,21 @@
       "current" : true
     },
     {
+      "version" : "0.11.0",
+      "path" : "http://fhir.org/templates/hl7.au.fhir.template/0.11.0",
+      "status" : "release",
+      "sequence" : "Publications",
+      "fhirversion" : "4.0.1",
+      "desc" : "Update the header HL7 AU logo link to point to the correct HL7 Australia website URL, and upgrade for dependency on fhir.base.template v0.10.0.",
+      "current" : true
+    },
+    {
       "version" : "0.10.0",
       "path" : "http://fhir.org/templates/hl7.au.fhir.template/0.10.0",
       "status" : "release",
       "sequence" : "Publications",
       "fhirversion" : "4.0.1",
       "desc" : "Upgrade for dependency on fhir.base.template v0.9.0.",
-      "current" : true,
       "date" : "2024-11-12"
     },
     {

--- a/package/package.json
+++ b/package/package.json
@@ -7,7 +7,7 @@
   "canonical" : "http://fhir.org/templates/hl7.au.fhir.template",
   "base" : "hl7.au.base.template",
   "dependencies" : {
-    "hl7.au.base.template" : "current"
+    "hl7.au.base.template" : "0.10.0"
   },
-  "version" : "0.10.0"
+  "version" : "0.11.0"
 }


### PR DESCRIPTION
v0.11.0:
- Update header image alt text and URL to point to HL7 AU website https://hl7.com.au/
- Update dependency on hl7.au.base.template 0.10.0